### PR TITLE
fix: 成功時のメッセージでSlack標準の絵文字を使用

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -4,7 +4,7 @@ const sendSuccessMessage = async (options, status = '', note = '', telework = ''
   const webhook = new IncomingWebhook(options.url);
   const blocks = [];
 
-  let text = ':check_mark: ' + status;
+  let text = ':white_check_mark: ' + status;
   if (telework) {
     text += ' ' + telework;
   }


### PR DESCRIPTION
`:check_mark:` はSlack標準として登録されている絵文字ではない。
Slack 標準として登録されている`:white_check_mark:` を使用する。