### PR TITLE
fix: Slack URL を登録していない場合に通知を試みてしまうのを修正

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -94,7 +94,9 @@ const runDakokuByMenu = async (task) => {
   });
   notification.show();
 
-  await slack.sendMessage(slackOptions, payload.slack.text, payload.slack.blocks);
+  if (slackOptions.url) {
+    await slack.sendMessage(slackOptions, payload.slack.text, payload.slack.blocks);
+  }
 };
 
 const getOptions = () => ({


### PR DESCRIPTION
fix #31