### PR TITLE
chore(workflow): MacOSビルド制限時間を増やす

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
   build_mac:
     name: Build for Mac OS
     runs-on: macos-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
時間超えることが多いので