### PR TITLE
feat: アプリの自動更新通知を追加

### DIFF
--- a/src/dakoku.ts
+++ b/src/dakoku.ts
@@ -1,5 +1,5 @@
 import * as akashi from 'akashi-dakoku-core';
-import { BrowserWindow, Notification, Tray } from 'electron';
+import { BrowserWindow, Notification } from 'electron';
 import { Block, KnownBlock } from '@slack/types';
 import * as pptr from './pptr';
 import * as slack from './slack';

--- a/src/dakoku.ts
+++ b/src/dakoku.ts
@@ -118,6 +118,6 @@ export const runByMenu = async (task: TaskType): Promise<void> => {
   }
 
   // 打刻時に更新がないか調べる
-  // 打刻通知と被るのを防ぐため30秒程度遅延させる
-  setTimeout(release.doIfReleaseExists, 30000);
+  // 打刻通知と被るのを防ぐため10秒程度遅延させる
+  setTimeout(release.doIfReleaseExists, 10000);
 };

--- a/src/dakoku.ts
+++ b/src/dakoku.ts
@@ -1,10 +1,13 @@
 import * as akashi from 'akashi-dakoku-core';
-import { BrowserWindow, Notification } from 'electron';
+import { BrowserWindow, Notification, Tray } from 'electron';
 import { Block, KnownBlock } from '@slack/types';
 import * as pptr from './pptr';
 import * as slack from './slack';
 import * as sound from './sound';
 import * as store from './store';
+import * as release from './release';
+import * as settingsWindow from './settings-window';
+import * as tray from './tray';
 import { sleep } from './utils/sleep';
 
 export type TaskType = keyof ReturnType<typeof akashi.dakoku>;
@@ -115,4 +118,8 @@ export const runByMenu = async (task: TaskType): Promise<void> => {
   if (slackOptions.url) {
     await slack.sendMessage(slackOptions, payload.slack.text, payload.slack.blocks);
   }
+
+  // 打刻時に更新がないか調べる
+  release.saveIfReleaseExists();
+  tray.initialize(settingsWindow.open, runByMenu, store.getShowDirectly(), store.getRelease());
 };

--- a/src/dakoku.ts
+++ b/src/dakoku.ts
@@ -6,8 +6,6 @@ import * as slack from './slack';
 import * as sound from './sound';
 import * as store from './store';
 import * as release from './release';
-import * as settingsWindow from './settings-window';
-import * as tray from './tray';
 import { sleep } from './utils/sleep';
 
 export type TaskType = keyof ReturnType<typeof akashi.dakoku>;
@@ -120,6 +118,6 @@ export const runByMenu = async (task: TaskType): Promise<void> => {
   }
 
   // 打刻時に更新がないか調べる
-  release.saveIfReleaseExists();
-  tray.initialize(settingsWindow.open, runByMenu, store.getShowDirectly(), store.getRelease());
+  // 打刻通知と被るのを防ぐため30秒程度遅延させる
+  setTimeout(release.doIfReleaseExists, 30000);
 };

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -15,6 +15,6 @@ export const subscribe = (): void => {
 
   ipcMain.handle('saveOtherOptions', (event, sound, showDirectly) => {
     store.saveOtherOptions(sound, showDirectly);
-    tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly());
+    tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), store.getRelease());
   });
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import * as pptr from './pptr';
 import * as settingsWindow from './settings-window';
 import * as store from './store';
 import * as tray from './tray';
+import * as release from './release';
 
 const initialize = async () => {
   store.initialize();
@@ -37,4 +38,8 @@ app.whenReady().then(async () => {
   if (!dakokuOptions.username || !dakokuOptions.password || !dakokuOptions.company) {
     settingsWindow.open();
   }
+
+  // 起動時に更新がないか調べる
+  await release.saveIfReleaseExists();
+  tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), store.getRelease());
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,5 @@ app.whenReady().then(async () => {
   }
 
   // 起動時に更新がないか調べる
-  await release.saveIfReleaseExists();
-  tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), store.getRelease());
+  await release.doIfReleaseExists();
 });

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,5 +1,5 @@
 import get from 'axios';
-import { app, Notification } from 'electron';
+import { app, Notification, shell } from 'electron';
 import * as dakoku from './dakoku';
 import * as settingsWindow from './settings-window';
 import * as store from './store';
@@ -64,6 +64,11 @@ export const doIfReleaseExists = async (): Promise<void> => {
       title: release.tag_name + ' がリリースされました！',
       body: 'メニューから新しい' + app.getName() + 'を入手しましょう！',
     });
+    notification.on('click', () => {
+      shell.openExternal(release.html_url);
+    });
     notification.show();
+  } else {
+    store.saveRelease(null);
   }
 };

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,6 +1,9 @@
 import get from 'axios';
-import { app } from 'electron';
-import { saveRelease } from './store';
+import { app, Notification } from 'electron';
+import * as dakoku from './dakoku';
+import * as settingsWindow from './settings-window';
+import * as store from './store';
+import * as tray from './tray';
 
 /** @see https://docs.github.com/en/rest/reference/repos#get-the-latest-release */
 const LATEST_API_URL = 'https://api.github.com/repos/TaneAkashi/DakokuApp/releases/latest';
@@ -52,9 +55,15 @@ const fetchLatest = async (): Promise<Release | null> => {
   return version;
 };
 
-export const saveIfReleaseExists = async (): Promise<void> => {
+export const doIfReleaseExists = async (): Promise<void> => {
   const release = await fetchLatest();
   if (release && release.tag_name.slice(1) !== app.getVersion()) {
-    saveRelease(release);
+    store.saveRelease(release);
+    tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), store.getRelease());
+    const notification = new Notification({
+      title: release.tag_name + ' がリリースされました！',
+      body: 'メニューから新しい' + app.getName() + 'を入手しましょう！',
+    });
+    notification.show();
   }
 };

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,7 +1,9 @@
 import get from 'axios';
+import { app } from 'electron';
+import { saveRelease } from './store';
 
 /** @see https://docs.github.com/en/rest/reference/repos#get-the-latest-release */
-const LATEST_API_URL = 'https://api.github.com/repos/TaneAkashi/dakoku-/releases/latest';
+const LATEST_API_URL = 'https://api.github.com/repos/TaneAkashi/DakokuApp/releases/latest';
 
 export type Release = {
   url: string;
@@ -43,9 +45,16 @@ export type Release = {
   body: string;
 };
 
-export const fetchLatest = async (): Promise<Release | null> => {
+const fetchLatest = async (): Promise<Release | null> => {
   const version = await get(LATEST_API_URL)
     .then((res) => res.data)
     .catch(() => null);
   return version;
+};
+
+export const saveIfReleaseExists = async (): Promise<void> => {
+  const release = await fetchLatest();
+  if (release && release.tag_name.slice(1) !== app.getVersion()) {
+    saveRelease(release);
+  }
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -163,5 +163,6 @@ export const saveOtherOptions = (sound: boolean, showDirectly: boolean): void =>
 export const saveRelease = (release: StoreRelease | null): void => {
   if (!store) throw new Error('store is not initialized.');
   // electron-store schema は object | null のような型を取れないので undefined を null とみなして扱う
-  store.set('release', release || undefined);
+  // electron-store は store.set(..., undefined) を許容しないため delete を行う
+  release ? store.set('release', release) : store.delete('release');
 };


### PR DESCRIPTION
fix: #12 

動作確認は akashi-dakoku: v0.5.0 をリリース先として行った。

<img width="380" alt="スクリーンショット 2021-05-15 13 48 28" src="https://user-images.githubusercontent.com/12657833/118348369-c1ffa800-b584-11eb-8975-966567b13fbc.png">

![スクリーンショット 2021-05-15 13 50 16](https://user-images.githubusercontent.com/12657833/118348371-c4fa9880-b584-11eb-8470-8f5eab1536f2.png)

クリックすると右のURLが開かれる https://github.com/TaneAkashi/akashi-dakoku/releases/tag/v0.5.0