### PR TITLE
feat: アップデート案内が毎回出ないよう変更

### DIFF
--- a/src/dakoku.ts
+++ b/src/dakoku.ts
@@ -131,7 +131,7 @@ export const runByMenu = async (task: TaskType): Promise<void> => {
 
   // 打刻時に更新がないか調べる
   // 打刻通知と被るのを防ぐため10秒程度遅延させる
-  setTimeout(release.doIfReleaseExists, 10000);
+  setTimeout(release.doIfNotLatest, 10000);
 };
 
 export const checkLogin = async (options: Options): Promise<boolean> => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -28,6 +28,6 @@ export const subscribe = (): void => {
 
   ipcMain.handle('saveOtherOptions', (event, sound, showDirectly) => {
     store.saveOtherOptions(sound, showDirectly);
-    tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), store.getRelease());
+    tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), store.getLatest());
   });
 };

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -3,6 +3,7 @@ import * as dakoku from './dakoku';
 import * as settingsWindow from './settings-window';
 import * as store from './store';
 import * as tray from './tray';
+import * as release from './release';
 
 export const subscribe = (): void => {
   ipcMain.handle(
@@ -28,6 +29,6 @@ export const subscribe = (): void => {
 
   ipcMain.handle('saveOtherOptions', (event, sound, showDirectly) => {
     store.saveOtherOptions(sound, showDirectly);
-    tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), store.getLatest());
+    tray.initialize(settingsWindow.open, dakoku.runByMenu, store.getShowDirectly(), release.getLatest());
   });
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,5 +40,5 @@ app.whenReady().then(async () => {
   }
 
   // 起動時に更新がないか調べる
-  await release.doIfReleaseExists();
+  release.doIfNotLatest();
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,5 +40,5 @@ app.whenReady().then(async () => {
   }
 
   // 起動時に更新がないか調べる
-  release.doIfNotLatest();
+  await release.doIfNotLatest();
 });

--- a/src/release.ts
+++ b/src/release.ts
@@ -88,7 +88,7 @@ const notifyIfNotNotified = () => {
   notified = latest.tag_name;
 };
 
-export const doIfNotLatest = async () => {
+export const doIfNotLatest = async (): Promise<void> => {
   await updateLatest();
 
   if (isLatest()) {

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,5 +1,5 @@
 import get from 'axios';
-import { app, Notification } from 'electron';
+import { app, Notification, shell } from 'electron';
 import * as dakoku from './dakoku';
 import * as settingsWindow from './settings-window';
 import * as store from './store';
@@ -84,6 +84,9 @@ const notifyIfNotNotified = () => {
   const notification = new Notification({
     title: latest.tag_name + 'がリリースされました！',
     body: 'メニューから新しい' + app.getName() + 'を入手しましょう！',
+  });
+  notification.on('click', () => {
+    shell.openExternal(latest.html_url);
   });
   notification.show();
 

--- a/src/release.ts
+++ b/src/release.ts
@@ -48,8 +48,6 @@ export type Release = {
   body: string;
 };
 
-let notified = '';
-
 const fetchLatest = async (): Promise<Release | null> => {
   const version = await get(LATEST_API_URL)
     .then((res) => res.data)
@@ -72,10 +70,14 @@ export const isLatest = (): boolean => {
   return !!latest && latest.tag_name.slice(1) === app.getVersion();
 };
 
+// 通知を管理する変数
+// 同じバージョンに対して行われる通知はアプリのライフサイクル毎に１回
+let notifiedVersion = '';
+
 const notifyIfNotNotified = () => {
   const latest = store.getLatest();
 
-  if (notified === latest.tag_name) {
+  if (notifiedVersion === latest.tag_name) {
     return;
   }
 
@@ -85,7 +87,7 @@ const notifyIfNotNotified = () => {
   });
   notification.show();
 
-  notified = latest.tag_name;
+  notifiedVersion = latest.tag_name;
 };
 
 export const doIfNotLatest = async (): Promise<void> => {

--- a/src/release.ts
+++ b/src/release.ts
@@ -48,6 +48,7 @@ export type Release = {
 /** @see https://docs.github.com/en/rest/reference/repos#get-the-latest-release */
 const LATEST_API_URL = 'https://api.github.com/repos/TaneAkashi/DakokuApp/releases/latest';
 
+// 最新の Release 情報
 let latestRelease: Release;
 
 export const getLatest = (): Release => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,11 +1,5 @@
 import Store, { Schema } from 'electron-store';
-import { Release } from './release';
 import { SoundPackId } from './sound';
-
-export type StoreRelease = Pick<
-  Release,
-  'html_url' | 'id' | 'node_id' | 'tag_name' | 'name' | 'draft' | 'prerelease' | 'body'
->;
 
 /*
 electron-storeのmigrationsの使用は、前方互換性の問題を考慮する必要がある。
@@ -27,7 +21,6 @@ type SchemaType = {
     icon_emoji: string;
     username: string;
   };
-  latest: StoreRelease;
 };
 
 let store: Store<SchemaType> | null = null;
@@ -77,10 +70,6 @@ const schema: Schema<SchemaType> = {
       url: '',
     },
     additionalProperties: false,
-  },
-  latest: {
-    type: 'object',
-    default: undefined,
   },
 };
 
@@ -134,11 +123,6 @@ export const getDakokuOptions = (): DakokuOptions => {
   };
 };
 
-export const getLatest = (): StoreRelease => {
-  if (!store) throw new Error('store is not initialized.');
-  return store.get('latest');
-};
-
 export const saveDakokuOptions = (email: string, password: string, company: string): void => {
   if (!store) throw new Error('store is not initialized.');
   store.set('username', email);
@@ -166,9 +150,4 @@ export const saveOtherOptions = (soundPack: SoundPackId, showDirectly: boolean):
   if (!store) throw new Error('store is not initialized.');
   store.set('soundPack', soundPack);
   store.set('showDirectly', showDirectly);
-};
-
-export const saveLatest = (latest: StoreRelease): void => {
-  if (!store) throw new Error('store is not initialized.');
-  store.set('latest', latest);
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ electron-storeのmigrationsの使用は、前方互換性の問題を考慮す�
 この問題を避けるため、キーの型を変えて使いたい場合、別名のキーを使用し、旧キー名は使用不可とする運用を採用する。
 以下のキーは過去に使用されたキーである。
 - [<=1.0.0] sound: boolean
+- [<=1.1.0] release: object
 */
 type SchemaType = {
   username: string;
@@ -26,7 +27,7 @@ type SchemaType = {
     icon_emoji: string;
     username: string;
   };
-  release: StoreRelease;
+  latest: StoreRelease;
 };
 
 let store: Store<SchemaType> | null = null;
@@ -77,7 +78,7 @@ const schema: Schema<SchemaType> = {
     },
     additionalProperties: false,
   },
-  release: {
+  latest: {
     type: 'object',
     default: undefined,
   },
@@ -133,10 +134,9 @@ export const getDakokuOptions = (): DakokuOptions => {
   };
 };
 
-export const getRelease = (): StoreRelease | null => {
+export const getLatest = (): StoreRelease => {
   if (!store) throw new Error('store is not initialized.');
-  // electron-store schema は object | null のような型を取れないので undefined を null とみなして扱う
-  return store.get('release') || null;
+  return store.get('latest');
 };
 
 export const saveDakokuOptions = (email: string, password: string, company: string): void => {
@@ -168,9 +168,7 @@ export const saveOtherOptions = (soundPack: SoundPackId, showDirectly: boolean):
   store.set('showDirectly', showDirectly);
 };
 
-export const saveRelease = (release: StoreRelease | null): void => {
+export const saveLatest = (latest: StoreRelease): void => {
   if (!store) throw new Error('store is not initialized.');
-  // electron-store schema は object | null のような型を取れないので undefined を null とみなして扱う
-  // electron-store は store.set(..., undefined) を許容しないため delete を行う
-  release ? store.set('release', release) : store.delete('release');
+  store.set('latest', latest);
 };

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { Menu, MenuItemConstructorOptions, MenuItem, Tray, app, shell } from 'electron';
 import { TaskType } from './dakoku';
-import { StoreRelease } from './store';
+import { Release } from './release';
 
 let tray: Tray | null = null;
 
@@ -16,7 +16,7 @@ const generateMenu = (
   open: () => void,
   run: (task: TaskType) => Promise<void>,
   showDirectly: boolean,
-  release: StoreRelease | null
+  release: Release | null
 ): (MenuItemConstructorOptions | MenuItem)[] => {
   const menu: (MenuItemConstructorOptions | MenuItem)[] = [];
 
@@ -125,7 +125,7 @@ export const initialize = (
   open: () => void,
   run: (task: TaskType) => Promise<void>,
   showDirectly: boolean,
-  release: StoreRelease | null = null
+  release: Release | null = null
 ): void => {
   if (tray) {
     tray.destroy();


### PR DESCRIPTION
fix: #92 

リリースに対して、アプリのライフサイクル毎に１回の通知が出ます。
つまり、アプリを再起動すると、同じリリースに対して再度通知が行われます。

ついでに、この修正でリリースの保存方法を変えます。